### PR TITLE
Fix for new config snapshot mechanism

### DIFF
--- a/src/ElasticApm/Impl/Config/Snapshot.php
+++ b/src/ElasticApm/Impl/Config/Snapshot.php
@@ -98,6 +98,9 @@ final class Snapshot implements LoggableInterface
     /** @var string */
     private $apiKey;
 
+    /** @var string */
+    private $atomicSite;
+
     /** @var bool */
     private $asyncBackendComm;
 

--- a/src/ext/ConfigSnapshot.h
+++ b/src/ext/ConfigSnapshot.h
@@ -37,6 +37,7 @@ struct ConfigSnapshot
     AssertLevel assertLevel;
         #endif
     String apiKey;
+    String atomicSite;
     bool astProcessEnabled;
     bool astProcessDebugDumpConvertedBackToSource;
     String astProcessDebugDumpForPathPrefix;


### PR DESCRIPTION
The upgrade from 1.8.0 to 1.8.4 broke our custom atomic sites addition due to the way config value handling changed. This fixes it.