### PR TITLE
Require Atomic Site ID

### DIFF
--- a/agent/native/ext/elastic_apm_API.c
+++ b/agent/native/ext/elastic_apm_API.c
@@ -20,6 +20,7 @@
 #include "elastic_apm_API.h"
 #include <unistd.h>
 #include <php.h>
+#include <php_main.h>
 #include "util.h"
 #include "log.h"
 #include "Tracer.h"
@@ -41,6 +42,11 @@ ResultCode elasticApmApiEntered( String dbgCalledFromFile, int dbgCalledFromLine
 
 bool elasticApmIsEnabled()
 {
+    const String atomicSite = getTracerCurrentConfigSnapshot( getGlobalTracer() )->atomicSite;
+    if ( atomicSite == NULL || atomicSite == "" || strcmp( sapi_module.name, "cli" ) == 0 ) {
+        return false;
+    }
+
     const bool result = getTracerCurrentConfigSnapshot( getGlobalTracer() )->enabled;
 
     ELASTIC_APM_LOG_TRACE( "Result: %s", boolToString( result ) );

--- a/agent/native/ext/elastic_apm_version.h
+++ b/agent/native/ext/elastic_apm_version.h
@@ -18,4 +18,4 @@
  */
 #pragma once
 
-#define PHP_ELASTIC_APM_VERSION "1.9.1"
+#define PHP_ELASTIC_APM_VERSION "1.9.1.1.a8c-02"


### PR DESCRIPTION
Don't turn the APM agent on unless we have an Atomic Site ID and are running not in CLI mode.